### PR TITLE
Handle situations where `instance.section` fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Changed
 
 ### Fixed
+- Handle situation where `instance.section` calls fail when using recursion with `#all_there?` ([luke-hill] - [#72])
 
 ## [3.0.2] - 2023-11-13
 ### Changed
@@ -201,6 +202,7 @@
 [luke-hill]:  https://github.com/luke-hill
 
 <!-- Issue/PR References to the repo -->
+[#72]:        https://github.com/site-prism/site_prism-all_there/pull/72
 [#70]:        https://github.com/site-prism/site_prism-all_there/pull/70
 [#69]:        https://github.com/site-prism/site_prism-all_there/pull/69
 [#61]:        https://github.com/site-prism/site_prism-all_there/pull/61

--- a/lib/site_prism/all_there/recursion_checker.rb
+++ b/lib/site_prism/all_there/recursion_checker.rb
@@ -45,7 +45,7 @@ module SitePrism
           SitePrism.logger.debug("Result of section_classes_all_there?: #{result}")
         end
       rescue Capybara::ElementNotFound
-        SitePrism.logger.error("Error whilst attempting to locate all section classes from within #{self.class}")
+        SitePrism.logger.error("Error whilst attempting to locate all section classes from within #{instance.class}")
         false
       end
 
@@ -54,7 +54,7 @@ module SitePrism
           SitePrism.logger.debug("Result of sections_classes_all_there?: #{result}")
         end
       rescue Capybara::ElementNotFound
-        SitePrism.logger.error("Error whilst attempting to locate all sections (plural), classes from within #{self.class}")
+        SitePrism.logger.error("Error whilst attempting to locate all sections (plural), classes from within #{instance.class}")
         false
       end
 

--- a/lib/site_prism/all_there/recursion_checker.rb
+++ b/lib/site_prism/all_there/recursion_checker.rb
@@ -44,12 +44,18 @@ module SitePrism
         section_classes_to_check.all? { |section| section.all_there?(**opts) }.tap do |result|
           SitePrism.logger.debug("Result of section_classes_all_there?: #{result}")
         end
+      rescue Capybara::ElementNotFound
+        SitePrism.logger.error("Error whilst attempting to locate all section classes from within #{self.class}")
+        false
       end
 
       def sections_classes_all_there?(**opts)
         sections_classes_to_check.flatten.all? { |section| section.all_there?(**opts) }.tap do |result|
           SitePrism.logger.debug("Result of sections_classes_all_there?: #{result}")
         end
+      rescue Capybara::ElementNotFound
+        SitePrism.logger.error("Error whilst attempting to locate all sections (plural), classes from within #{self.class}")
+        false
       end
 
       def section_classes_to_check


### PR DESCRIPTION
Handle situations where Capybara cannot find an element - return false