### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ on:
   pull_request:
     branches:
       - main
+permissions:
+  contents: read
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/site-prism/site_prism-all_there/security/code-scanning/1](https://github.com/site-prism/site_prism-all_there/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/ci.yml` at the workflow root so it applies to all jobs (including `test`) unless overridden. For this CI workflow, the minimal least-privilege setting is:

- `contents: read`

This preserves current behavior (checkout and read-only operations) while constraining token scope. No imports, methods, or dependencies are needed—just a YAML edit near the top-level keys (after `on:` and before `jobs:` is a clean placement).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
